### PR TITLE
Add GCS bucket to store benchmark outputs

### DIFF
--- a/create.sh
+++ b/create.sh
@@ -13,7 +13,7 @@ if [[ -z "$RUNNER_URL" ]]; then
 fi
 
 # Deploy infrastructure
-scripts/deploy_infrastructure.sh ${PROJECT_NAME}
+PROJECT_NAME=${PROJECT_NAME} scripts/deploy_infrastructure.sh
 
 PROJECT_ID=$(terraform output google_project_id)
 REGION=$(terraform output region)

--- a/create.sh
+++ b/create.sh
@@ -17,11 +17,9 @@ scripts/deploy_infrastructure.sh ${PROJECT_NAME}
 
 PROJECT_ID=$(terraform output google_project_id)
 REGION=$(terraform output region)
-# Login to cluster
-gcloud container clusters get-credentials runner-benchmark --region ${REGION} --project ${PROJECT_ID}
-
 GCS_OUTPUT_BUCKET=$(terraform output benchmark-output-storage)
-scripts/deploy_benchmark.sh ${RUNNER_URL} ${GCS_OUTPUT_BUCKET}
+
+PROJECT_ID=${PROJECT_ID} REGION=${REGION} RUNNER_URL=${RUNNER_URL} GCS_OUTPUT_BUCKET=${GCS_OUTPUT_BUCKET} ./scripts/deploy_benchmark.sh
 
 echo
 echo "Testing Survey Runner URL: ${RUNNER_URL}"

--- a/create.sh
+++ b/create.sh
@@ -14,7 +14,14 @@ fi
 
 # Deploy infrastructure
 scripts/deploy_infrastructure.sh ${PROJECT_NAME}
-scripts/deploy_benchmark.sh ${RUNNER_URL}
+
+PROJECT_ID=$(terraform output google_project_id)
+REGION=$(terraform output region)
+# Login to cluster
+gcloud container clusters get-credentials runner-benchmark --region ${REGION} --project ${PROJECT_ID}
+
+GCS_OUTPUT_BUCKET=$(terraform output benchmark-output-storage)
+scripts/deploy_benchmark.sh ${RUNNER_URL} ${GCS_OUTPUT_BUCKET}
 
 echo
 echo "Testing Survey Runner URL: ${RUNNER_URL}"

--- a/destroy.sh
+++ b/destroy.sh
@@ -8,4 +8,4 @@ if [[ -z "$PROJECT_NAME" ]]; then
 fi
 
 # Destroy infrastructure
-scripts/destroy_infrastructure.sh ${PROJECT_NAME}
+PROJECT_NAME=${PROJECT_NAME} scripts/destroy_infrastructure.sh

--- a/main.tf
+++ b/main.tf
@@ -38,6 +38,13 @@ output "google_project_id" {
   value = "${google_project.project.project_id}"
 }
 
+resource "google_project_service" "container" {
+  project = "${google_project.project.project_id}"
+  service = "container.googleapis.com"
+
+  disable_dependent_services = true
+}
+
 resource "google_project_service" "compute" {
   project = "${google_project.project.project_id}"
   service = "compute.googleapis.com"
@@ -124,11 +131,28 @@ resource "google_container_node_pool" "main-node-pool" {
 
     oauth_scopes = [
       "compute-rw",
+      "storage-rw",
       "logging-write",
-      "monitoring"
+      "monitoring",
     ]
 
     service_account = "${google_service_account.compute.email}"
     tags            = ["k8s-node", "default-node-pool"]
   }
+}
+
+resource "google_storage_bucket" "benchmark-output-storage" {
+  name          = "${google_project.project.project_id}-benchmark-outputs"
+  location      = "${var.region}"
+  force_destroy = "true"
+  project       = "${google_project.project.project_id}"
+
+  retention_policy {
+    is_locked        = false
+    retention_period = 604800
+  }
+}
+
+output "benchmark-output-storage" {
+  value = "${google_storage_bucket.benchmark-output-storage.name}"
 }

--- a/main.tf
+++ b/main.tf
@@ -149,7 +149,7 @@ resource "google_storage_bucket" "benchmark-output-storage" {
 
   retention_policy {
     is_locked        = false
-    retention_period = 604800
+    retention_period = 31536000
   }
 }
 

--- a/scripts/deploy_benchmark.sh
+++ b/scripts/deploy_benchmark.sh
@@ -5,7 +5,7 @@ set -e
 TEMP_DIR=$(mktemp -d)
 
 # Clone benchmark repo
-git clone --branch store_results_in_storge_bucket --depth 1 https://github.com/ONSdigital/eq-survey-runner-benchmark.git "${TEMP_DIR}"/eq-survey-runner-benchmark
+git clone --branch master --depth 1 https://github.com/ONSdigital/eq-survey-runner-benchmark.git "${TEMP_DIR}"/eq-survey-runner-benchmark
 
 cd ${TEMP_DIR}/eq-survey-runner-benchmark
 
@@ -18,7 +18,7 @@ helm tiller run \
     k8s/helm \
     --set host=${RUNNER_URL} \
     --set locustOptions="--no-web -c 1 -r 1 -t 1m --csv=output -L WARNING" \
-    --set container.image=eu.gcr.io/census-eq-ci/eq-survey-runner-benchmark:store_results_in_storge_bucket \
+    --set container.image=eu.gcr.io/census-eq-ci/eq-survey-runner-benchmark:latest \
     --set output.bucket=${GCS_OUTPUT_BUCKET}
 
 rm -rf "${TEMP_DIR}"

--- a/scripts/deploy_benchmark.sh
+++ b/scripts/deploy_benchmark.sh
@@ -4,7 +4,7 @@ set -e
 
 TEMP_DIR=$(mktemp -d)
 
-# Clone Launcher Repo
+# Clone benchmark repo
 git clone --branch store_results_in_storge_bucket --depth 1 https://github.com/ONSdigital/eq-survey-runner-benchmark.git "${TEMP_DIR}"/eq-survey-runner-benchmark
 
 cd ${TEMP_DIR}/eq-survey-runner-benchmark

--- a/scripts/deploy_benchmark.sh
+++ b/scripts/deploy_benchmark.sh
@@ -3,10 +3,11 @@
 set -e
 
 RUNNER_URL=$1
+GCS_OUTPUT_BUCKET=$2
 TEMP_DIR=$(mktemp -d)
 
 # Clone Launcher Repo
-git clone --branch master --depth 1 https://github.com/ONSdigital/eq-survey-runner-benchmark.git "${TEMP_DIR}"/eq-survey-runner-benchmark
+git clone --branch store_results_in_storge_bucket --depth 1 https://github.com/ONSdigital/eq-survey-runner-benchmark.git "${TEMP_DIR}"/eq-survey-runner-benchmark
 
 cd ${TEMP_DIR}/eq-survey-runner-benchmark
 
@@ -15,6 +16,8 @@ helm tiller run \
     runner-benchmark \
     k8s/helm \
     --set host=${RUNNER_URL} \
-    --set container.image=eu.gcr.io/census-eq-ci/eq-survey-runner-benchmark:latest
+    --set locustOptions="--no-web -c 1 -r 1 -t 1m --csv=output -L WARNING" \
+    --set container.image=eu.gcr.io/census-eq-ci/eq-survey-runner-benchmark:store-output \
+    --set gcsOutputBucket=${GCS_OUTPUT_BUCKET}
 
 rm -rf "${TEMP_DIR}"

--- a/scripts/deploy_benchmark.sh
+++ b/scripts/deploy_benchmark.sh
@@ -2,8 +2,6 @@
 
 set -e
 
-RUNNER_URL=$1
-GCS_OUTPUT_BUCKET=$2
 TEMP_DIR=$(mktemp -d)
 
 # Clone Launcher Repo
@@ -11,13 +9,16 @@ git clone --branch store_results_in_storge_bucket --depth 1 https://github.com/O
 
 cd ${TEMP_DIR}/eq-survey-runner-benchmark
 
+# Login to cluster
+gcloud container clusters get-credentials runner-benchmark --region ${REGION} --project ${PROJECT_ID}
+
 helm tiller run \
     helm upgrade --install \
     runner-benchmark \
     k8s/helm \
     --set host=${RUNNER_URL} \
     --set locustOptions="--no-web -c 1 -r 1 -t 1m --csv=output -L WARNING" \
-    --set container.image=eu.gcr.io/census-eq-ci/eq-survey-runner-benchmark:store-output \
-    --set gcsOutputBucket=${GCS_OUTPUT_BUCKET}
+    --set container.image=eu.gcr.io/census-eq-ci/eq-survey-runner-benchmark:store_results_in_storge_bucket \
+    --set output.bucket=${GCS_OUTPUT_BUCKET}
 
 rm -rf "${TEMP_DIR}"

--- a/scripts/deploy_infrastructure.sh
+++ b/scripts/deploy_infrastructure.sh
@@ -2,7 +2,6 @@
 
 set -ex
 
-PROJECT_NAME=$1
 TERRAFORM_STATE_BUCKET="${TERRAFORM_STATE_BUCKET:-eq-terraform-load-generator-tfstate}"
 IMPORT_EXISTING_PROJECT="${IMPORT_EXISTING_PROJECT:-false}"
 

--- a/scripts/deploy_infrastructure.sh
+++ b/scripts/deploy_infrastructure.sh
@@ -21,9 +21,3 @@ fi
 
 # Roll out infrastructure
 terraform apply -auto-approve -var "project_name=${PROJECT_NAME}"
-
-PROJECT_ID=$(terraform output google_project_id)
-REGION=$(terraform output region)
-
-# Login to cluster
-gcloud container clusters get-credentials runner-benchmark --region ${REGION} --project ${PROJECT_ID}

--- a/scripts/destroy_infrastructure.sh
+++ b/scripts/destroy_infrastructure.sh
@@ -2,7 +2,6 @@
 
 set -e
 
-PROJECT_NAME=$1
 TERRAFORM_STATE_BUCKET="${TERRAFORM_STATE_BUCKET:-eq-terraform-load-generator-tfstate}"
 
 terraform init --upgrade --backend-config prefix=${PROJECT_NAME} -var "project_name=${PROJECT_NAME}" --backend-config bucket=${TERRAFORM_STATE_BUCKET}


### PR DESCRIPTION
This PR adds a new GCS bucket in which benchmark results can be stored.

### How to review:
- Follow the README to create an environment and ensure that the outputs of the benchmark are stored in a bucket named `<project-id-benchmark-outputs`.