### PR TITLE
Specify project_name when importing project

### DIFF
--- a/scripts/deploy_infrastructure.sh
+++ b/scripts/deploy_infrastructure.sh
@@ -14,7 +14,7 @@ if [ "$IMPORT_EXISTING_PROJECT" = true ]; then
         echo "State contains a google project. Not importing"
     else
         echo "State does not contain a google project. Importing $PROJECT_NAME"
-        terraform import google_project.project $PROJECT_NAME
+        terraform import -var "project_name=${PROJECT_NAME}" google_project.project $PROJECT_NAME
     fi
 fi
 


### PR DESCRIPTION
This PR fixes an issue when importing an existing project.

### How to review
- Create a project on GCP.
- Deploy the infrastructure where `IMPORT_EXISTING_PROJECT` is true.
```bash
PROJECT_NAME=<project_name> IMPORT_EXISTING_PROJECT=true RUNNER_URL=<runner_url>./create.sh
```
- Ensure infrastructure is deployed as expected.