### PR TITLE
Add a variable machine_type

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -133,7 +133,7 @@ resource "google_container_node_pool" "main-node-pool" {
   }
 
   node_config {
-    machine_type = "n1-standard-1"
+    machine_type = var.machine_type
 
     oauth_scopes = [
       "compute-rw",

--- a/variables.tf
+++ b/variables.tf
@@ -28,3 +28,8 @@ variable "k8s_min_master_version" {
   description = "The minimum version of the master"
   default     = "1.13"
 }
+
+variable "machine_type" {
+  description = "The machine type to provision"
+  default     = "n1-standard-1"
+}


### PR DESCRIPTION
Adds a new variable `machine_type` to configure the specific machine type that the nodes should be built with.