### PR TITLE
Update k8s min master version

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,5 @@
+### What is the context of this PR?
+Describe what you have changed and why, link to other PRs or Issues as appropriate.
+
+### How to review 
+Describe the steps required to test the changes (include screenshots if appropriate).

--- a/variables.tf
+++ b/variables.tf
@@ -16,7 +16,7 @@ variable "project_id" {
 
 variable "k8s_min_master_version" {
   description = "The minimum version of the master"
-  default     = "1.13"
+  default     = "1.14"
 }
 
 variable "machine_type" {


### PR DESCRIPTION
### What is the context of this PR?
Our current Kubernetes master version is  1.13.12-gke.30, this is no longer available hence all new envs will fail ie why benchmark also failed this morning. We need to upgrade to 1.14.10-gke.24 at least and also update our min master version in terraform.
https://cloud.google.com/kubernetes-engine/docs/release-notes#march_16_2020

This PR updates the version to the next latest stable version.

### How to review 
Ensure you can deploy the load generator as expected.