### PR TITLE
Make max node count configurable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -95,7 +95,7 @@ resource "google_container_node_pool" "main-node-pool" {
 
   autoscaling {
     min_node_count = 1
-    max_node_count = 5
+    max_node_count = var.k8s_autoscaling_max_node_count
   }
 
   management {
@@ -104,7 +104,7 @@ resource "google_container_node_pool" "main-node-pool" {
   }
 
   node_config {
-    machine_type = var.machine_type
+    machine_type = var.k8s_machine_type
 
     oauth_scopes = [
       "compute-rw",

--- a/variables.tf
+++ b/variables.tf
@@ -19,7 +19,12 @@ variable "k8s_min_master_version" {
   default     = "1.14"
 }
 
-variable "machine_type" {
+variable "k8s_machine_type" {
   description = "The machine type to provision"
   default     = "n1-standard-1"
+}
+
+variable "k8s_autoscaling_max_node_count" {
+  description = "The maximum number of Kubernetes nodes (per region)"
+  default     = 5
 }


### PR DESCRIPTION
### What is the context of this PR?
Adds a `k8s_autoscaling_max_node_count` variable so we can run more than the default maximum of 5 nodes (per zone) in our stress test.

`machine_type` was updated to `k8s_machine_type` for consistency.