### PR TITLE
Upgrade GKE min master version to 1.15

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -16,7 +16,7 @@ variable "project_id" {
 
 variable "k8s_min_master_version" {
   description = "The minimum version of the master"
-  default     = "1.14"
+  default     = "1.15"
 }
 
 variable "k8s_machine_type" {


### PR DESCRIPTION
### What is the context of this PR?
Our current Kubernetes master version is  1.14, this is no longer available hence all new envs will fail. We need to upgrade to 1.15 which is the latest stable version.
https://cloud.google.com/kubernetes-engine/docs/release-notes#august_06_2020_r26
This PR updates the version to the next latest stable version.

### How to review 
- Ensure you can deploy the environment as expected.
- Existing env work as expected.