### PR TITLE
Upgrade k8s_min_master_version to 1.15

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -16,7 +16,7 @@ variable "project_id" {
 
 variable "k8s_min_master_version" {
   description = "The minimum version of the master"
-  default     = "1.14"
+  default     = "1.15"
 }
 
 variable "k8s_machine_type" {


### PR DESCRIPTION
1.14 of Kubernetes no longer supported in GCP.
Updating to 1.15 to overcome immediate failure.
Considering/investing if auto upgrade of minor versions is appropriate/available (out of scope for this PR)