### PR TITLE
Upgrade k8s_min_master_version to 1.16

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -16,7 +16,7 @@ variable "project_id" {
 
 variable "k8s_min_master_version" {
   description = "The minimum version of the master"
-  default     = "1.15"
+  default     = "1.16"
 }
 
 variable "k8s_machine_type" {


### PR DESCRIPTION
### What is the context of this PR?
Updates to the latest stable version for k8s as per https://cloud.google.com/kubernetes-engine/docs/release-notes-stable

### How to review 
- Ensure deployment of the load generator works as expected.

My dev and daily test envs are using this branch, if you want to use that as guides.