### PR TITLE
remove un used varibles as this was not required in the latest provider

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -69,9 +69,6 @@ resource "google_container_cluster" "runner-benchmark" {
 
   // Basic auth is disabled by setting user/pass to empty strings
   master_auth {
-    username = ""
-    password = ""
-
     client_certificate_config {
       issue_client_certificate = false
     }

--- a/main.tf
+++ b/main.tf
@@ -67,7 +67,6 @@ resource "google_container_cluster" "runner-benchmark" {
   project                  = var.project_id
   network                  = google_compute_network.k8s.self_link
 
-  // Basic auth is disabled by setting user/pass to empty strings
   master_auth {
     client_certificate_config {
       issue_client_certificate = false


### PR DESCRIPTION
## What is the context of this PR?
- this change is to resolve a issue with the latest terraform google provider 4.0
- The latest provider version has remove username and password attributes
- when running terraform getting errors : Error: Unsupported argument
## How to review
- created a GCP project
- updated variables to point to the GCP project
- removed the username and password arguments from the google_container_cluster resource
- created a test pipeline to validate that the issue is not present
https://concourse.gcp.onsdigital.uk/teams/eq-dev/pipelines/kev-terraform

Note: Formal pipelines will be auto flown on merge to master
If updating formal pipelines, the #ctot-census-ops-updates slack channel will need to be updated as the prod pipeline will be flown on merge