### PR TITLE
Add container dependency to prevent race condition 

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -58,6 +58,7 @@ resource "google_project_iam_member" "compute" {
 }
 
 resource "google_container_cluster" "runner-benchmark" {
+  depends_on               = [google_project_service.container]
   name                     = "runner-benchmark"
   description              = "Kubernetes Cluster - Dev Benchmark environment"
   location                 = var.region
@@ -76,7 +77,7 @@ resource "google_container_cluster" "runner-benchmark" {
 }
 
 resource "google_container_node_pool" "main-node-pool" {
-  depends_on = [google_container_cluster.runner-benchmark, google_project_service.container, google_project_iam_member.compute]
+  depends_on = [google_project_service.container]
   name       = "main-node-pool"
   location   = var.region
   cluster    = google_container_cluster.runner-benchmark.name

--- a/main.tf
+++ b/main.tf
@@ -76,7 +76,7 @@ resource "google_container_cluster" "runner-benchmark" {
 }
 
 resource "google_container_node_pool" "main-node-pool" {
-  depends_on = [google_container_cluster.runner-benchmark]
+  depends_on = [google_container_cluster.runner-benchmark, google_project_service.container]
   name       = "main-node-pool"
   location   = var.region
   cluster    = google_container_cluster.runner-benchmark.name

--- a/main.tf
+++ b/main.tf
@@ -76,7 +76,7 @@ resource "google_container_cluster" "runner-benchmark" {
 }
 
 resource "google_container_node_pool" "main-node-pool" {
-  depends_on = [google_container_cluster.runner-benchmark, google_project_service.container]
+  depends_on = [google_container_cluster.runner-benchmark, google_project_service.container, google_project_iam_member.compute]
   name       = "main-node-pool"
   location   = var.region
   cluster    = google_container_cluster.runner-benchmark.name

--- a/main.tf
+++ b/main.tf
@@ -76,6 +76,7 @@ resource "google_container_cluster" "runner-benchmark" {
 }
 
 resource "google_container_node_pool" "main-node-pool" {
+  depends_on = [google_project_service.k8s]
   name       = "main-node-pool"
   location   = var.region
   cluster    = google_container_cluster.runner-benchmark.name

--- a/main.tf
+++ b/main.tf
@@ -76,7 +76,7 @@ resource "google_container_cluster" "runner-benchmark" {
 }
 
 resource "google_container_node_pool" "main-node-pool" {
-  depends_on = [google_project_service.k8s]
+  depends_on = [google_compute_network.k8s]
   name       = "main-node-pool"
   location   = var.region
   cluster    = google_container_cluster.runner-benchmark.name

--- a/main.tf
+++ b/main.tf
@@ -76,7 +76,7 @@ resource "google_container_cluster" "runner-benchmark" {
 }
 
 resource "google_container_node_pool" "main-node-pool" {
-  depends_on = [google_compute_network.k8s, google_service_account.compute]
+  depends_on = [google_container_cluster.runner-benchmark]
   name       = "main-node-pool"
   location   = var.region
   cluster    = google_container_cluster.runner-benchmark.name

--- a/main.tf
+++ b/main.tf
@@ -76,7 +76,7 @@ resource "google_container_cluster" "runner-benchmark" {
 }
 
 resource "google_container_node_pool" "main-node-pool" {
-  depends_on = [google_compute_network.k8s]
+  depends_on = [google_compute_network.k8s, google_service_account.compute]
   name       = "main-node-pool"
   location   = var.region
   cluster    = google_container_cluster.runner-benchmark.name


### PR DESCRIPTION
### What is the context of this PR?
To fix the daily benchmark issue we have to add dependecies in the `google_container_node_pool.main-node-pool` and `google_container_cluster.runner-benchmark` as they both rely on the `google_project_service.container` being present before they get destroyed and built. They both depend on that resource now in the main.tf.

### How to review
Run daily benchmark and check if destroy step passes.

#### Note: Before merging, the repo should be scanned with `tfsec` and any new issues identified should be resolved or logged [in this confluence doc](https://collaborate2.ons.gov.uk/confluence/pages/viewpage.action?spaceKey=SDC&title=EQ+Security+and+Vulnerabilities).
