### PR TITLE
Migrate CI tasks to use registry-image

### DIFF
--- a/ci/deploy-infrastructure.yaml
+++ b/ci/deploy-infrastructure.yaml
@@ -5,7 +5,7 @@ params:
   GOOGLE_APPLICATION_CREDENTIALS: /root/gcloud-service-key.json
   PROJECT_ID:
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     repository: ((image_registry))/eq-infrastructure-deploy-image
     tag: ((deploy_image_version))

--- a/ci/destroy-infrastructure.yaml
+++ b/ci/destroy-infrastructure.yaml
@@ -5,7 +5,7 @@ params:
   GOOGLE_APPLICATION_CREDENTIALS: /root/gcloud-service-key.json
   PROJECT_ID:
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     repository: ((image_registry))/eq-infrastructure-deploy-image
     tag: ((deploy_image_version))


### PR DESCRIPTION
What is the context of this PR?
Migrates our CI tasks in Runner to use registry-image rather than docker-image

How to review
Ensure the pipelines that reference these tasks are still working.

#### Note: Before merging, the repo should be scanned with `tfsec` and any new issues identified should be resolved or logged [in this confluence doc](https://collaborate2.ons.gov.uk/confluence/pages/viewpage.action?spaceKey=SDC&title=EQ+Security+and+Vulnerabilities).
