### PR TITLE
Migrate to docker image repo

### DIFF
--- a/ci/deploy-infrastructure.yaml
+++ b/ci/deploy-infrastructure.yaml
@@ -7,7 +7,7 @@ params:
 image_resource:
   type: registry-image
   source:
-    repository: ((image_registry))/eq-infrastructure-deploy-image
+    repository: ((image_registry))/eq-terraform-deploy-image
     tag: ((deploy_image_version))
 run:
   path: bash

--- a/ci/destroy-infrastructure.yaml
+++ b/ci/destroy-infrastructure.yaml
@@ -7,7 +7,7 @@ params:
 image_resource:
   type: registry-image
   source:
-    repository: ((image_registry))/eq-infrastructure-deploy-image
+    repository: ((image_registry))/eq-terraform-deploy-image
     tag: ((deploy_image_version))
 run:
   path: bash


### PR DESCRIPTION
### What is the context of this PR?
We're migrating eQ pipeline resources to point at our centralised custom Docker file repo: https://github.com/ONSdigital/eq-runner-docker-images

### How to review
Push up each of the Dockerfiles from above, and set your dev pipeline `image_registry` var to point to your dockerfile registry. The pipeline job should still pass.

#### Note: Before merging, the repo should be scanned with `tfsec` and any new issues identified should be resolved or logged [in this confluence doc](https://collaborate2.ons.gov.uk/confluence/pages/viewpage.action?spaceKey=SDC&title=EQ+Security+and+Vulnerabilities).
