### PR TITLE
Configure cluster maintenance policy window

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -74,6 +74,14 @@ resource "google_container_cluster" "runner-benchmark" {
       issue_client_certificate = false
     }
   }
+
+  maintenance_policy {
+    daily_maintenance_window {
+      // GMT
+      start_time = "05:00"
+    }
+  }
+
 }
 
 resource "google_container_node_pool" "main-node-pool" {


### PR DESCRIPTION
### What is the context of this PR?
Configures a maintenance policy window for our k8s cluster, this is in response to an org policy change that requires this to be configured explicitly on all clusters. The time set (5am) is fairly arbitrary as our benchmark is spun up and torn down in a short space of time as part of the workflow, so it shouldn't be up for long enough for maintenance.

### How to review
Check the policy is set as expected when deploying the tf.

#### Note: Before merging, the repo should be scanned with `tfsec` and any new issues identified should be resolved or logged [in this confluence doc](https://collaborate2.ons.gov.uk/confluence/pages/viewpage.action?spaceKey=SDC&title=EQ+Security+and+Vulnerabilities).
