### PR TITLE
Add bucket uniform level access 

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -126,10 +126,11 @@ resource "google_container_node_pool" "main-node-pool" {
 }
 
 resource "google_storage_bucket" "benchmark-output-storage" {
-  name          = "${var.project_id}-outputs"
-  location      = var.region
-  force_destroy = "true"
-  project       = var.project_id
+  name                        = "${var.project_id}-outputs"
+  location                    = var.region
+  force_destroy               = "true"
+  project                     = var.project_id
+  uniform_bucket_level_access = true
 
   retention_policy {
     is_locked        = false


### PR DESCRIPTION
### What is the context of this PR?
Uniform level access (https://cloud.google.com/storage/docs/uniform-bucket-level-access) is now required for buckets in our infrastructure, existing terraform resource had to be changed. These changes ensure that the outputs bucket is created with the specified access control settings. 

### How to review
Test by flying a daily benchmark pipeline and use this branch of eq-terraform-load-generator. Test if it deploys as expected now and slack task has access to the outputs bucket.

#### Note: Before merging, the repo should be scanned with `tfsec` and any new issues identified should be resolved or logged [in this confluence doc](https://collaborate2.ons.gov.uk/confluence/pages/viewpage.action?spaceKey=SDC&title=EQ+Security+and+Vulnerabilities).
