### PR TITLE
EQS-837: Fix teardown benchmark GCP errors

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -18,6 +18,7 @@ resource "google_project_service" "container" {
   service = "container.googleapis.com"
 
   disable_dependent_services = true
+  disable_on_destroy         = false
 }
 
 resource "google_project_service" "compute" {

--- a/scripts/destroy_infrastructure.sh
+++ b/scripts/destroy_infrastructure.sh
@@ -13,4 +13,4 @@ terraform state rm google_storage_bucket.benchmark-output-storage
 terraform destroy --auto-approve -var "project_id=${PROJECT_ID}"
 
 # Import bucket resource back into the state
-terraform import -var "project_id=${PROJECT_ID}" google_storage_bucket.benchmark-output-storage "${PROJECT_ID}"-outputs
+terraform import -var "project_id=${PROJECT_ID}" google_storage_bucket.benchmark-output-storage "${PROJECT_ID}/${PROJECT_ID}"-outputs

--- a/variables.tf
+++ b/variables.tf
@@ -11,13 +11,13 @@ variable "project_id" {
 variable "k8s_min_master_version" {
   type        = string
   description = "The minimum version of the master"
-  default     = "1.17"
+  default     = "1.33"
 }
 
 variable "k8s_machine_type" {
   type        = string
   description = "The machine type to provision"
-  default     = "n1-standard-1"
+  default     = "custom-2-2560"
 }
 
 variable "k8s_autoscaling_max_node_count" {


### PR DESCRIPTION
### What is the context of this PR?
Our benchmark Terraform start-up & teardown pipeline tasks were encountering the following issues:
* The teardown task was erroring due to GCP blocking the disabling of `container.googleapis.com` when cluster/node pool resources still existed. This has now been fixed by keeping the API enabled on destroy, preventing Terraform trying to disable the API
* The above error was then impacting the startup job and the bucket address was mismatched, so Terraform attempted to destroy the outputs bucket. This has now been fixed by giving the full resource path to Terraform during the state import step. 

I've also updated the base `variables.tf` file to align with our pipeline defaults for consistency.

### How to review
1. In your dev benchmark pipeline, point to this branch
2. Run the pipeline all of the way through, then repeat once - there should be no errors

#### Note: Before merging, the repo should be scanned with `MegaLinter` and any new issues identified should be resolved or logged [in this confluence doc](https://confluence.ons.gov.uk/display/SDC/eQ%3A+Security+and+Vulnerabilities+Log).
