### PR TITLE
EQS-1224-fix-k8s-min-master-version

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -77,11 +77,11 @@ resource "google_container_cluster" "runner-benchmark" {
   #checkov:skip=CKV_GCP_21:Ensure Kubernetes Clusters are configured with Labels
   #chekov:skip=CKV_GCP_20:Ensure master authorized networks is set to enabled in GKE clusters
   #checkov:skip=CKV_GCP_65:Manage Kubernetes RBAC users with Google Groups for GKE
-  depends_on               = [google_project_service.container]
-  name                     = "runner-benchmark"
-  description              = "Kubernetes Cluster - Dev Benchmark environment"
-  location                 = var.region
-  min_master_version       = var.k8s_min_master_version
+  depends_on  = [google_project_service.container]
+  name        = "runner-benchmark"
+  description = "Kubernetes Cluster - Dev Benchmark environment"
+  location    = var.region
+  # min_master_version       = var.k8s_min_master_version
   initial_node_count       = 1
   remove_default_node_pool = true
   project                  = var.project_id
@@ -114,7 +114,7 @@ resource "google_container_node_pool" "main-node-pool" {
   cluster    = google_container_cluster.runner-benchmark.name
   node_count = 1
   project    = var.project_id
-  version    = var.k8s_min_master_version
+  # version    = var.k8s_min_master_version
 
   lifecycle {
     ignore_changes = [

--- a/main.tf
+++ b/main.tf
@@ -77,11 +77,10 @@ resource "google_container_cluster" "runner-benchmark" {
   #checkov:skip=CKV_GCP_21:Ensure Kubernetes Clusters are configured with Labels
   #chekov:skip=CKV_GCP_20:Ensure master authorized networks is set to enabled in GKE clusters
   #checkov:skip=CKV_GCP_65:Manage Kubernetes RBAC users with Google Groups for GKE
-  depends_on  = [google_project_service.container]
-  name        = "runner-benchmark"
-  description = "Kubernetes Cluster - Dev Benchmark environment"
-  location    = var.region
-  # min_master_version       = var.k8s_min_master_version
+  depends_on               = [google_project_service.container]
+  name                     = "runner-benchmark"
+  description              = "Kubernetes Cluster - Dev Benchmark environment"
+  location                 = var.region
   initial_node_count       = 1
   remove_default_node_pool = true
   project                  = var.project_id
@@ -114,7 +113,6 @@ resource "google_container_node_pool" "main-node-pool" {
   cluster    = google_container_cluster.runner-benchmark.name
   node_count = 1
   project    = var.project_id
-  # version    = var.k8s_min_master_version
 
   lifecycle {
     ignore_changes = [

--- a/variables.tf
+++ b/variables.tf
@@ -8,11 +8,11 @@ variable "project_id" {
   description = "The project id in GCP"
 }
 
-variable "k8s_min_master_version" {
+/* variable "k8s_min_master_version" {
   type        = string
   description = "The minimum version of the master"
   default     = "1.33"
-}
+} */
 
 variable "k8s_machine_type" {
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -8,12 +8,6 @@ variable "project_id" {
   description = "The project id in GCP"
 }
 
-/* variable "k8s_min_master_version" {
-  type        = string
-  description = "The minimum version of the master"
-  default     = "1.33"
-} */
-
 variable "k8s_machine_type" {
   type        = string
   description = "The machine type to provision"


### PR DESCRIPTION
### What is the context of this PR?
The daily benchmark was failing during GKE infrastructure creation because k8s_min_master_version was hard coded to 1.33, which is no longer available.
This PR removes the k8s_min_master_version variable from the terraform load generator. 

### How to review
Confirm the k8s_min_master_version variable has been removed from variables.tf
Confirm min_master_version has been removed from the GKE resource
Confirm the version reference has been removed.
Related PR for testing [eq-pipelines](https://github.com/ONSdigital/eq-pipelines/pull/759)

#### Note: Before merging, the repo should be scanned with `MegaLinter` and any new issues identified should be resolved or logged [in this confluence doc](https://confluence.ons.gov.uk/display/SDC/eQ%3A+Security+and+Vulnerabilities+Log).
